### PR TITLE
Added pressKey() and releaseKey()

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ $result = $api->getPresets();
 foreach ($result as $preset) {
     print 'Preset '.$preset->getId().' : '.$preset->getContentItem()->getSource().' / '.$preset->getContentItem()->getName()."\n";
 }
+
+// Play preset No. 1
+$api->playPreset(1);
+
+// Set current source as preset No. 5
+$api->setPreset(5);
 ~~~
 
 

--- a/src/SoundTouchApi.php
+++ b/src/SoundTouchApi.php
@@ -121,21 +121,46 @@ class SoundTouchApi
 
 
     /**
-     * Envoie une commande de touche à l'enceinte
-     * 
+     * Send the pressing *and* releasing of a key to the speaker
+     *
      * @param String $key
      * @return Response
      */
     public function setKey($key)
     {
+        $result = $this->pressKey($key);
+        if (!$result) return $result;
+        $result = $this->releaseKey($key);
+        return $result;
+    }
+
+    /**
+     * Send the pressing of a key to the speaker
+     *
+     * @param String $key
+     * @return Response
+     */
+    public function pressKey($key)
+    {
         $request = new SetKeyRequest();
         $request->setKey( $key )->setState( SetKeyRequest::PRESS );
         $result = $this->client->request( $request );
-        if (!$result) return false;
-        $request->setKey( $key )->setState( SetKeyRequest::RELEASE );
-        return $this->client->request( $request );
+        return $result;
     }
 
+    /**
+     * Send the releasing of a key to the speaker
+     *
+     * @param String $key
+     * @return Response
+     */
+    public function releaseKey($key)
+    {
+        $request = new SetKeyRequest();
+        $request->setKey( $key )->setState( SetKeyRequest::RELEASE );
+        $result = $this->client->request( $request );
+        return $result;
+    }
 
     /**
      * Retourne le volume de l'enceinte
@@ -317,5 +342,15 @@ class SoundTouchApi
     public function shuffleOff() { return $this->setKey(Key::SHUFFLE_OFF); }
 
     public function power() { return $this->setKey(Key::POWER); }
+
+    public function setPreset($id)
+    {
+        return $this->pressKey(constant(Key::class . '::PRESET_' . (string)$id));
+    }
+
+    public function playPreset($id)
+    {
+        return $this->releaseKey(constant(Key::class . '::PRESET_' . (string)$id));
+    }
 
 }


### PR DESCRIPTION
Bonjour,

I wasn't able to set a new preset, because the `$api->setKey(xxx)` is implemented as a press followed by a release of the same key. Is there any particular reason to implement it like that?

Anyway, with that implementation alone I wasn't able to set a new preset, because for that we need only a release of the preset buttons. See https://developer.bose.com/guides/bose-soundtouch-api/bose-soundtouch-api-reference#keyPost (scroll up a little to see that section) for further information.

I've distinguish `setKey()` into `pressKey()` and `releaseKey()` and added aliases `setPreset(x)` and `playPreset(x)`.

Cheers, Philipp